### PR TITLE
Add missing supported_features flags for fan and climate

### DIFF
--- a/custom_components/intellifire_hacs/climate.py
+++ b/custom_components/intellifire_hacs/climate.py
@@ -49,7 +49,8 @@ class IntellifireClimate(IntellifireEntity, ClimateEntity):
     _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
     _attr_min_temp = 0
     _attr_max_temp = 37
-    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _enable_turn_on_off_backwards_compatibility = False
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
     _attr_target_temperature_step = 1.0
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     last_temp = DEFAULT_THERMOSTAT_TEMP
@@ -114,3 +115,9 @@ class IntellifireClimate(IntellifireEntity, ClimateEntity):
         # 2) Make sure the fireplace is on!
         if not self.coordinator.read_api.data.is_on:
             await self.coordinator.control_api.flame_on()
+
+    async def async_turn_off(self) -> None:
+        await self.async_set_hvac_mode(HVACMode.OFF)
+
+    async def async_turn_on(self) -> None:
+        await self.async_set_hvac_mode(HVACMode.HEAT)

--- a/custom_components/intellifire_hacs/fan.py
+++ b/custom_components/intellifire_hacs/fan.py
@@ -75,7 +75,7 @@ class IntellifireFan(IntellifireEntity, FanEntity):
     """Fan entity for the fireplace."""
 
     entity_description: IntellifireFanEntityDescription
-    _attr_supported_features = FanEntityFeature.SET_SPEED
+    _attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
Fixes issue #2 

* Added `supported_features` flags `TURN_ON` and `TURN_OFF` for the climate and fan entities.
* Implemented `turn_on` and `turn_off` methods for climate entity.

These changes get rid of the startup log warnings for the `IntellifireClimate` and `IntellifireFan` classes.